### PR TITLE
bring back `git ls-files|grep $1` :persevere:

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -77,8 +77,7 @@ alias grhh='git reset HEAD --hard'
 alias gclean='git reset --hard && git clean -dfx'
 alias gwc='git whatchanged -p --abbrev-commit --pretty=medium'
 
-#remove the gf alias
-#alias gf='git ls-files | grep'
+alias gfg='git ls-files | grep'
 
 alias gpoat='git push origin --all && git push origin --tags'
 alias gmt='git mergetool --no-prompt'


### PR DESCRIPTION
gf is aliased to `git flow` right now 
