### PR TITLE
use ls instead of find to avoid incompatibility with gnu find

### DIFF
--- a/plugins/xcode/xcode.plugin.zsh
+++ b/plugins/xcode/xcode.plugin.zsh
@@ -1,6 +1,6 @@
 #xc function courtesy of http://gist.github.com/subdigital/5420709
 function xc {
-  xcode_proj=`find . -name "*.xc*" -d 1 | sort -r | head -1`
+  xcode_proj=`ls | grep "\.xc" | sort -r | head -1`
   if [[ `echo -n $xcode_proj | wc -m` == 0 ]]
   then
     echo "No xcworkspace/xcodeproj file found in the current directory."


### PR DESCRIPTION
with GNU find this warning is shown

```
find: warning: you have specified the -d option after a non-option argument -name, but options are not positional (-d affects tests specified before it as well as those specified after it).  Please specify options before other arguments.

find: warning: the -d option is deprecated; please use -depth instead, because the latter is a POSIX-compliant feature.
find: paths must precede expression: 1
Usage: find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec] [path...] [expression]
```
