### PR TITLE
Bring git ls files grep back

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -248,6 +248,8 @@ alias gignore='git update-index --assume-unchanged'
 alias gunignore='git update-index --no-assume-unchanged'
 # List temporarily ignored files
 alias gignored='git ls-files -v | grep "^[[:lower:]]"'
+# Grep list of files in the index
+alias gfg='git ls-files | grep'
 # Submodules
 alias gf='git fetch'
 compdef _git gf=git-fetch


### PR DESCRIPTION
it was removed in this change: https://github.com/robbyrussell/oh-my-zsh/commit/00848cd8b7347e9b793a2ac6170498e6592dde56
