### PR TITLE
Change parameter checks and other style fixes

### DIFF
--- a/plugins/omz-bootstrap/_omz
+++ b/plugins/omz-bootstrap/_omz
@@ -144,3 +144,4 @@ _themes () {
   _describe -t themes 'theme' themes && return 0
 }
 
+_omz

--- a/plugins/omz-bootstrap/lib/download.zsh
+++ b/plugins/omz-bootstrap/lib/download.zsh
@@ -1,22 +1,21 @@
 _clone_git() {
-  local url=$1
-  local folder=$2
+  local url=$1; local folder=$2
   if [[ ! -d "$folder" ]]; then
-    git clone $url $folder
+    command git clone $url $folder
   fi
 }
 
 _download_plugin() {
-  [[ "$#" != 2 ]] && return 1
-  local url=$1; local name=$2;
+  [[ -z "$1" || -z "$2" ]] && return 1
+  local url=$1; local name=$2
   _clone_git $url $ZSH_CUSTOM/plugins/$name
   _map_put plugins $name enabled
 }
 
 _download_theme() {
-  [[ "$#" != 2 ]] && return 1
-  local url=$1; local theme=$2;
+  [[ -z "$1" || -z "$2" ]] && return 1
+  local url=$1; local theme=$2
   _clone_git $url $ZSH_CUSTOM/themes/$theme
-  ln -s $ZSH_CUSTOM/themes/$theme/$theme.zsh-theme $ZSH_CUSTOM/$theme.zsh-theme
+  command ln -s $ZSH_CUSTOM/themes/$theme/$theme.zsh-theme $ZSH_CUSTOM/$theme.zsh-theme
   _map_put themes theme $theme
 }

--- a/plugins/omz-bootstrap/lib/map.zsh
+++ b/plugins/omz-bootstrap/lib/map.zsh
@@ -1,40 +1,40 @@
-mapdir=$ZSH/cache/omz-bootstrap
+mapdir="$ZSH/cache/omz-bootstrap"
 
 _map_init() {
-  mkdir -p $mapdir
+  command mkdir -p "$mapdir"
 }
 
 _map_put() {
-  [[ "$#" != 3 ]] && return 1
-  mapname=$1; key=$2; value=$3
+  [[ -z "$1" || -z "$2" || -z "$3" ]] && return 1
+  local mapname=$1; local key=$2; local value=$3
   [[ -d "${mapdir}/${mapname}" ]] || mkdir "${mapdir}/${mapname}"
-  echo $value >"${mapdir}/${mapname}/${key}"
+  echo $value > "${mapdir}/${mapname}/${key}"
 }
 
 _map_get() {
-  [[ "$#" != 2 ]] && return 1
-  mapname=$1; key=$2
+  [[ -z "$1" || -z "$2" ]] && return 1
+  local mapname=$1; local key=$2
   cat "${mapdir}/${mapname}/${key}"
 }
 
 _map_keys() {
-  [[ "$#" != 1 ]] && return 1
-  mapname=$1
+  [[ -z "$1" ]] && return 1
+  local mapname=$1
   for key ($mapdir/$mapname/*); do
     basename $key
   done
 }
 
 _map_exists() {
-  [[ "$#" != 2 ]] && return 1
-  mapname=$1; key=$2
+  [[ -z "$1" || -z "$2" ]] && return 1
+  local mapname=$1; local key=$2
   [[ -f "${mapdir}/${mapname}/${key}" ]] && return 0
 }
 
 _map_remove() {
-  [[ "$#" != 2 ]] && return 1
-  mapname=$1; key=$2
-  rm "${mapdir}/${mapname}/${key}"  
+  [[ -z "$1" || -z "$2" ]] && return 1
+  local mapname=$1; local key=$2
+  command rm "${mapdir}/${mapname}/${key}"
 }
-_map_init
 
+_map_init

--- a/plugins/omz-bootstrap/lib/repository.zsh
+++ b/plugins/omz-bootstrap/lib/repository.zsh
@@ -21,7 +21,7 @@ _list_plugins() {
       printf "%-30s \033[0;32m%-10s\033[0m\n" $plugin_name $enabled
     else
       printf "%-30s \033[0;30m%-10s\033[0m\n" $plugin_name $enabled
-    fi 
+    fi
   done
 }
 
@@ -56,7 +56,7 @@ _list_enabled_plugins() {
 }
 
 _enable_plugin() {
-  [[ "$#" != 1 ]] && return 1
+  [[ -z "$1" ]] && return 1
   local plugin=$1
   _map_exists plugins $plugin
   if [[ $? -ne 0 ]]; then
@@ -65,13 +65,13 @@ _enable_plugin() {
 }
 
 _enable_theme() {
-  [[ "$#" != 1 ]] && return 1
+  [[ -z "$1" ]] && return 1
   local theme=$1
   _map_put themes theme $theme
 }
 
 _disable_plugin() {
-  [[ "$#" != 1 ]] && return 1
+  [[ -z "$1" ]] && return 1
   local plugin=$1
   local enabled=$(_map_get plugins $plugin)
   [[ $enabled = "enabled" ]] && _map_remove plugins $plugin
@@ -106,27 +106,26 @@ _populate_enabled_theme() {
 }
 
 _update_plugin() {
-  [[ "$#" != 1 ]] && return 1
+  [[ -z "$1" ]] && return 1
   local plugin=$1
   if [[ -d $ZSH_CUSTOM/plugins/$plugin ]]; then
-    pushd $ZSH_CUSTOM/plugins/$plugin > /dev/null
-    git pull
-    popd > /dev/null
+    command pushd $ZSH_CUSTOM/plugins/$plugin > /dev/null
+    command git pull
+    command popd > /dev/null
   fi
 }
 
 _update_theme() {
-  [[ "$#" != 1 ]] && return 1
+  [[ -z "$1" ]] && return 1
   local theme=$1
   if [[ -d $ZSH_CUSTOM/themes/$theme ]]; then
-    pushd $ZSH_CUSTOM/themes/$theme > /dev/null
-    git pull
-    popd > /dev/null
+    command pushd $ZSH_CUSTOM/themes/$theme > /dev/null
+    command git pull
+    command popd > /dev/null
   fi
 }
 
-
-
+# initialize repository
 _pre_enable_plugins
 _populate_enabled_plugins
 _init_theme

--- a/plugins/omz-bootstrap/omz-bootstrap.plugin.zsh
+++ b/plugins/omz-bootstrap/omz-bootstrap.plugin.zsh
@@ -1,37 +1,34 @@
-_load_bootstrap() {
-  export ZSH_BOOTSTRAP=$1
-  source $ZSH_BOOTSTRAP/lib/map.zsh
-  source $ZSH_BOOTSTRAP/lib/repository.zsh
-  source $ZSH_BOOTSTRAP/lib/download.zsh
-}
+DIR="$(dirname "$0")"
+source "$DIR/lib/map.zsh"
+source "$DIR/lib/repository.zsh"
+source "$DIR/lib/download.zsh"
+unset DIR
 
-[[ -f $ZSH_CUSTOM/plugins/omz-bootstrap/omz-bootstrap.plugin.zsh ]] && _load_bootstrap $ZSH_CUSTOM/plugins/omz-bootstrap
-[[ -f $ZSH/plugins/omz-bootstrap/omz-bootstrap.plugin.zsh ]] && _load_bootstrap $ZSH/plugins/omz-bootstrap
 
 usage='Usage: omz { plugin | theme } <cmd> [<options>]'
 usage_p='Usage: omz plugin <cmd> [<options>]
 Commands:
-  ls\tlist available plugins
-  on <name>\tenable a plugin
-  off <name>\tdisable a plugin
-  up <name>\tupdate a plugin
-  get <git-url> <name>\tdownload and enable a plugin'
+  ls                    list available plugins
+  on  <name>            enable a plugin
+  off <name>            disable a plugin
+  up  <name>            update a plugin
+  get <git-url> <name>  download and enable a plugin'
 usage_t='Usage: omz theme <cmd> [<options>]
 Commands:
-  ls\tlist available themes
-  set <name>\tset a theme
-  up <name>\tupdate a theme
-  get <git-url> <name>\tdownload and enable a theme'
+  ls                    list available themes
+  set <name>            set a theme
+  up  <name>            update a theme
+  get <git-url> <name>  download and enable a theme'
 
 omz () {
   case "$1" in
     (plugin)
       case "$2" in
         (ls)
-          _list_plugins|less
+          _list_plugins | less
         ;;
         (on)
-          _enable_plugin "$3"&&_populate_enabled_plugins "$3"
+          _enable_plugin "$3" && _populate_enabled_plugins "$3"
         ;;
         (off)
           _disable_plugin "$3"
@@ -40,7 +37,7 @@ omz () {
           _update_plugin "$3"
         ;;
         (get)
-          _download_plugin "$3" "$4"&&_populate_enabled_plugins "$4"
+          _download_plugin "$3" "$4" && _populate_enabled_plugins "$4"
         ;;
         (-h|--help|help)
           echo $usage_p
@@ -54,16 +51,16 @@ omz () {
     (theme)
       case "$2" in
         (ls)
-          _list_themes|less
+          _list_themes | less
         ;;
         (set)
-          _enable_theme "$3"&&_populate_enabled_theme
+          _enable_theme "$3" && _populate_enabled_theme
         ;;
         (up)
           _update_theme "$3"
         ;;
         (get)
-          _download_theme "$3" "$4"&&_populate_enabled_theme
+          _download_theme "$3" "$4" && _populate_enabled_theme
         ;;
         (-h|--help|help)
           echo $usage_t
@@ -72,7 +69,7 @@ omz () {
           echo $usage_t
           return 20
         ;;
-      esac 
+      esac
     ;;
     (-h|--help|help)
       echo $usage
@@ -84,4 +81,3 @@ omz () {
   esac
 }
 
-compdef _omz omz


### PR DESCRIPTION
This commits contains the following modifications:
- Change parameter checks from number of parameters (`$#`) to content length of
  each parameter ( `-z "$1"` ).
  A command called with an empty string in the first parameter _still_ receives one
  parameter (`$# = 1`), while checking the string length will work either way.
- Change commands that may be aliased to use the builtin / non-modified
  command, using the 'command' prefix (e.g. `git` -> `command git`).
- Changed the initialization sequence of the plugin, from using a function
  to being inline in the script.
  It also uses the $0 parameter which is set when the script is sourced, and
  it contains the script filepath.
  Example: with command `source test.sh` -> in test.sh, `$0` will be 'test.sh'.
- Various style fixes, including missing space and some comments.
