### PR TITLE
Add `gbda` for deleting merged branches

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -52,6 +52,7 @@ alias ga='git add'
 
 alias gb='git branch'
 alias gba='git branch -a'
+alias gbda='git branch --merged | command grep -vE "^(\*|\s*master\s*$)" | command xargs -n 1 git branch -d'
 alias gbl='git blame -b -w'
 alias gbnm='git branch --no-merged'
 alias gbr='git branch --remote'


### PR DESCRIPTION
This PR addresses the feedback provided in https://github.com/robbyrussell/oh-my-zsh/pull/3781.

- Added it in alphabetical order
- Removed the unnecessary `\`
- Added `\` for `grep` and `xargs` to bypass aliases there